### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -157,7 +157,7 @@
   title = {Combinatorial approaches to viral attenuation},
   journal = {bioRxiv},
   pages = {29918},
-  url = {http://dx.doi.org/10.1101/299180}
+  url = {https://doi.org/10.1101/299180}
 }
 
 @book{TufteQuantDispl,

--- a/docs/balance-data-ink.html
+++ b/docs/balance-data-ink.html
@@ -398,7 +398,7 @@ Figure 20.15: Gene expression levels in a mutant bacteriophage T7 relative to wi
 <p>Wickham, H. 2016. <em>ggplot2: Elegant Graphics for Data Analysis</em>. 2nd ed. New York: Springer.</p>
 </div>
 <div id="ref-Paffetal2018">
-<p>Paff, M. L., B. R. Jack, B. L. Smith, J. J. Bull, and C. O. Wilke. 2018. “Combinatorial Approaches to Viral Attenuation.” <em>bioRxiv</em>, 29918. <a href="http://dx.doi.org/10.1101/299180" class="uri">http://dx.doi.org/10.1101/299180</a>.</p>
+<p>Paff, M. L., B. R. Jack, B. L. Smith, J. J. Bull, and C. O. Wilke. 2018. “Combinatorial Approaches to Viral Attenuation.” <em>bioRxiv</em>, 29918. <a href="https://doi.org/10.1101/299180" class="uri">https://doi.org/10.1101/299180</a>.</p>
 </div>
 </div>
             </section>

--- a/docs/references.html
+++ b/docs/references.html
@@ -279,7 +279,7 @@
 <p>Okabe, M., and K. Ito. 2008. “Color Universal Design (CUD): How to Make Figures and Presentations That Are Friendly to Colorblind People.” <a href="http://jfly.iam.u-tokyo.ac.jp/color/" class="uri">http://jfly.iam.u-tokyo.ac.jp/color/</a>.</p>
 </div>
 <div>
-<p>Paff, M. L., B. R. Jack, B. L. Smith, J. J. Bull, and C. O. Wilke. 2018. “Combinatorial Approaches to Viral Attenuation.” <em>bioRxiv</em>, 29918. <a href="http://dx.doi.org/10.1101/299180" class="uri">http://dx.doi.org/10.1101/299180</a>.</p>
+<p>Paff, M. L., B. R. Jack, B. L. Smith, J. J. Bull, and C. O. Wilke. 2018. “Combinatorial Approaches to Viral Attenuation.” <em>bioRxiv</em>, 29918. <a href="https://doi.org/10.1101/299180" class="uri">https://doi.org/10.1101/299180</a>.</p>
 </div>
 <div>
 <p>Schimel, J. 2011. <em>Writing Science: How to Write Papers That Get Cited and Proposals That Get Funded</em>. Oxford University Press.</p>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links.

Cheers!